### PR TITLE
get rid of clangd inlay hints

### DIFF
--- a/nvim/plugin/lspconfig.lua
+++ b/nvim/plugin/lspconfig.lua
@@ -156,8 +156,6 @@ require('lz.n').load {
               border = 'none',
             },
           }
-          require('clangd_extensions.inlay_hints').setup_autocmd()
-          require('clangd_extensions.inlay_hints').set_inlay_hints()
         end,
 
         root_dir = function(fname)
@@ -198,6 +196,8 @@ require('lz.n').load {
           clangdFileStatus = true,
         },
       },
+
+      pyright = {},
 
       lua_ls = {
         settings = {


### PR DESCRIPTION
kind of conflicts with neovim's built in stuff i think